### PR TITLE
Add `--write-shape` argument to `zarrs_reencode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
  - Add `zarrs_validate` to check that arrays are equivalent
+ - Add `--write-shape` argument to `zarrs_reencode`
+   - This enables writing sharded arrays incrementally
 
 ### Changed
  - [#12](https://github.com/LDeakin/zarrs_tools/pull/12) Bump netcdf to 0.10.2 by [@magnusuMET]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,7 +2400,7 @@ dependencies = [
 [[package]]
 name = "zarrs"
 version = "0.18.0-dev"
-source = "git+https://github.com/LDeakin/zarrs.git#dc38c6bab2c1dfccf1d593efb4113aa2efc64ca8"
+source = "git+https://github.com/LDeakin/zarrs.git#330ce8651b919d82dc2824e2236b5442eac1a38b"
 dependencies = [
  "async-trait",
  "blosc-src",
@@ -2434,7 +2434,7 @@ dependencies = [
 [[package]]
 name = "zarrs_filesystem"
 version = "0.1.0"
-source = "git+https://github.com/LDeakin/zarrs.git#dc38c6bab2c1dfccf1d593efb4113aa2efc64ca8"
+source = "git+https://github.com/LDeakin/zarrs.git#330ce8651b919d82dc2824e2236b5442eac1a38b"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2451,7 +2451,7 @@ dependencies = [
 [[package]]
 name = "zarrs_metadata"
 version = "0.2.0"
-source = "git+https://github.com/LDeakin/zarrs.git#dc38c6bab2c1dfccf1d593efb4113aa2efc64ca8"
+source = "git+https://github.com/LDeakin/zarrs.git#330ce8651b919d82dc2824e2236b5442eac1a38b"
 dependencies = [
  "derive_more",
  "half",
@@ -2466,7 +2466,7 @@ dependencies = [
 [[package]]
 name = "zarrs_opendal"
 version = "0.3.1"
-source = "git+https://github.com/LDeakin/zarrs.git#dc38c6bab2c1dfccf1d593efb4113aa2efc64ca8"
+source = "git+https://github.com/LDeakin/zarrs.git#330ce8651b919d82dc2824e2236b5442eac1a38b"
 dependencies = [
  "async-trait",
  "futures",
@@ -2477,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "zarrs_storage"
 version = "0.3.0-dev"
-source = "git+https://github.com/LDeakin/zarrs.git#dc38c6bab2c1dfccf1d593efb4113aa2efc64ca8"
+source = "git+https://github.com/LDeakin/zarrs.git#330ce8651b919d82dc2824e2236b5442eac1a38b"
 dependencies = [
  "async-trait",
  "bytes",

--- a/src/bin/zarrs_reencode.rs
+++ b/src/bin/zarrs_reencode.rs
@@ -71,7 +71,7 @@ struct Args {
     /// This parameter is ignored for unsharded arrays (the write shape is the chunk shape).
     ///
     /// Prefer to set the write shape to an integer multiple of the chunk shape to avoid unnecessary reads.
-    /// 
+    ///
     #[arg(long, verbatim_doc_comment, value_delimiter = ',')]
     write_shape: Option<Vec<NonZeroU64>>,
 }

--- a/src/bin/zarrs_reencode.rs
+++ b/src/bin/zarrs_reencode.rs
@@ -1,4 +1,5 @@
 use core::f32;
+use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use clap::Parser;
@@ -62,6 +63,17 @@ struct Args {
     /// An optional per-thread chunk cache size (in chunks).
     #[arg(long)]
     cache_chunks_thread: Option<u64>,
+
+    /// Write shape (optional). A comma separated list of the write size along each array dimension.
+    ///
+    /// Use this parameter to incrementally write shards in batches of chunks of the specified write shape.
+    /// The write shape defaults to the shard shape for sharded arrays.
+    /// This parameter is ignored for unsharded arrays (the write shape is the chunk shape).
+    ///
+    /// Prefer to set the write shape to an integer multiple of the chunk shape to avoid unnecessary reads.
+    /// 
+    #[arg(long, verbatim_doc_comment, value_delimiter = ',')]
+    write_shape: Option<Vec<NonZeroU64>>,
 }
 
 fn bar_style_run() -> ProgressStyle {
@@ -181,6 +193,7 @@ fn main() -> anyhow::Result<()> {
         args.concurrent_chunks,
         &progress_callback,
         cache_size,
+        args.write_shape,
     )?;
     bar.set_style(bar_style_finish());
     bar.finish_and_clear();


### PR DESCRIPTION
This enables writing sharded arrays incrementally.

Example:
```bash
zarrs_reencode \
    --shard-shape 512,512,512 \
    --chunk-shape 32,32,32 \
    --write-shape 256,256,256 \
    array.zarr incremental.zarr
zarrs_validate array.zarr incremental.zarr
```

Closes #9 